### PR TITLE
Restore weight helpers for legacy algos

### DIFF
--- a/faircare/algos/aggregator.py
+++ b/faircare/algos/aggregator.py
@@ -1,6 +1,6 @@
 # faircare/algos/aggregator.py
 import math
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, Sequence
 import numpy as np
 
 class FedAvgAggregator:
@@ -10,6 +10,90 @@ class FedAvgAggregator:
         total = sum(w for _, w in weights) + 1e-12
         agg = sum(delta * (w / total) for delta, w in weights)
         return agg
+
+
+def _extract_reports(payloads: Sequence[Dict]) -> List[Dict]:
+    """Normalize a variety of legacy payload formats.
+
+    Returns a list of dictionaries with ``loss``, ``gap`` and ``num_samples``
+    keys populated (missing values default to ``0``).
+    """
+
+    reports: List[Dict] = []
+    for pl in payloads:
+        if isinstance(pl, dict):
+            rep = pl.get("report", pl)
+        elif isinstance(pl, (list, tuple)) and pl and isinstance(pl[0], dict):
+            rep = pl[0]
+        else:
+            raise TypeError("Unsupported payload format for weighting")
+
+        loss = rep.get("loss", rep.get("val_loss", rep.get("train_loss", 0.0)))
+        gap = rep.get("gap")
+        if gap is None:
+            summary = rep.get("summary", {})
+            if isinstance(summary, dict):
+                gap = summary.get("dp_gap", summary.get("eo_gap", 0.0))
+            else:
+                gap = 0.0
+        num = rep.get("num_samples", rep.get("n", rep.get("num", 0)))
+        reports.append({"loss": float(loss), "gap": float(gap), "num_samples": int(num)})
+    return reports
+
+
+def weights_fedavg(payloads: Sequence[Dict]) -> np.ndarray:
+    """Standard FedAvg weighting based on client sample counts."""
+
+    reps = _extract_reports(payloads)
+    ns = np.array([r.get("num_samples", 0) for r in reps], dtype=np.float64)
+    total = ns.sum() + 1e-12
+    return ns / total
+
+
+def weights_fairfed(payloads: Sequence[Dict], eps: float = 1e-6) -> np.ndarray:
+    """FairFed-style weights favouring clients with larger fairness gaps."""
+
+    reps = _extract_reports(payloads)
+    gaps = np.array([r.get("gap", 0.0) for r in reps], dtype=np.float64)
+    inv = 1.0 / (np.maximum(gaps, eps))
+    inv = inv / (inv.sum() + 1e-12)
+    return inv
+
+
+def weights_qffl(payloads: Sequence[Dict], q: float) -> np.ndarray:
+    """q-FFL weighting – emphasises high-loss clients."""
+
+    reps = _extract_reports(payloads)
+    losses = np.array([max(r.get("loss", 1e-12), 1e-12) for r in reps], dtype=np.float64)
+    w = losses ** q
+    return w / (w.sum() + 1e-12)
+
+
+def weights_afl(payloads: Sequence[Dict], boost: float = 5.0) -> np.ndarray:
+    """AFL weighting using an exponential boost on client losses."""
+
+    reps = _extract_reports(payloads)
+    losses = np.array([r.get("loss", 0.0) for r in reps], dtype=np.float64)
+    w = np.exp(boost * losses)
+    return w / (w.sum() + 1e-12)
+
+def normalize_weights(weights: Sequence[float]) -> np.ndarray:
+    """Normalize a list of weights so they sum to one."""
+    w = np.asarray(list(weights), dtype=np.float64)
+    return w / (w.sum() + 1e-12)
+
+def weights_faircare(
+    payloads: Sequence[Dict],
+    q: float = 0.5,
+    gamma: float = 1.0,
+    eps: float = 1e-3,
+    clip: float = 5.0,
+    temperature: float = 1.0,
+) -> np.ndarray:
+    """Legacy FairCare weighting helper."""
+    reps = _extract_reports(payloads)
+    fw = FairnessAwareWeights(q=q, gamma=gamma, eps=eps, clip=clip, temperature=temperature)
+    return fw(reps)
 
 class FairnessAwareWeights:
     """

--- a/faircare/data/partition.py
+++ b/faircare/data/partition.py
@@ -1,12 +1,42 @@
 # faircare/data/partition.py
 import numpy as np
-from typing import List
+from typing import List, Union, Sequence
 
-def dirichlet_partition(n: int, num_clients: int, alpha: float, seed: int = 42) -> List[np.ndarray]:
+def dirichlet_partition(
+    data_or_n: Union[int, Sequence],
+    num_clients: int,
+    alpha: float,
+    seed: int = 42,
+) -> List[np.ndarray]:
+    """Partition indices using a Dirichlet distribution.
+
+    Parameters
+    ----------
+    data_or_n:
+        Either the dataset/labels to be partitioned or the number of samples.
+    num_clients:
+        Number of client partitions to produce.
+    alpha:
+        Dirichlet concentration parameter controlling non-IID severity.
+    seed:
+        Random seed for reproducibility.
+
+    Returns
+    -------
+    List[np.ndarray]
+        A list of index arrays, one per client.
+    """
+
     rng = np.random.default_rng(seed)
+
+    if isinstance(data_or_n, (int, np.integer)):
+        n = int(data_or_n)
+    else:  # assume sequence/array-like
+        n = len(data_or_n)
+
     idx = np.arange(n)
     rng.shuffle(idx)
-    props = rng.dirichlet(alpha=[alpha]*num_clients, size=n)
+    props = rng.dirichlet(alpha=[alpha] * num_clients, size=n)
     buckets = [[] for _ in range(num_clients)]
     for i, p in enumerate(props):
         c = rng.choice(num_clients, p=p)

--- a/faircare/fairness/metrics.py
+++ b/faircare/fairness/metrics.py
@@ -97,3 +97,29 @@ def threshold_sweep(y_true: np.ndarray, y_prob: np.ndarray, s: np.ndarray) -> Di
         "best_eo":  {"threshold": float(best_eo[0]),  **best_eo[1]},
         "best_dp":  {"threshold": float(best_dp[0]),  **best_dp[1]},
     }
+
+# Backwards compatibility exports
+def dp_gap(*args) -> float:
+    """Demographic parity gap with flexible signature."""
+    if len(args) == 2:  # (y_pred, s)
+        y_pred, s = args
+    elif len(args) == 3:  # (y_true, y_pred, s)
+        _, y_pred, s = args
+    else:
+        raise TypeError("dp_gap expects (y_pred, s) or (y_true, y_pred, s)")
+    return _dp_gap(np.asarray(y_pred), np.asarray(s))
+
+eo_gap = _eo_gap
+fpr_gap = _fpr_gap
+calibration_ece = expected_calibration_error
+confusion_by_group = _confusion_by_group
+
+__all__ = [
+    "dp_gap",
+    "eo_gap",
+    "fpr_gap",
+    "calibration_ece",
+    "confusion_by_group",
+    "compute_metrics",
+    "threshold_sweep",
+]


### PR DESCRIPTION
## Summary
- normalize various legacy client reports for aggregation and re-expose `normalize_weights` & `weights_faircare`
- allow `dirichlet_partition` to accept either sample counts or label arrays
- re-export fairness metrics with a backward-compatible `dp_gap` signature

## Testing
- `PYTHONPATH=$(pwd) pytest -q`
- `PYTHONPATH=$(pwd) python -m faircare.experiments.run_experiments --outdir /tmp/exp_out --rounds 1 --num_clients 2 --dataset heart --global_eval` *(fails: ConnectionError: Error connecting to server)*

------
https://chatgpt.com/codex/tasks/task_e_6897b4903f78832fac12102538f50ab5